### PR TITLE
WIP: Add SampleRate to pipe constructor

### DIFF
--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -45,10 +45,12 @@ func TestPipe(t *testing.T) {
 		BufferSize: bufferSize,
 	}
 	processor := &mock.Processor{}
+	sampleRate := phono.SampleRate(44100)
 
 	for _, test := range tests {
 		sink := &asset.Asset{}
 		p := pipe.New(
+			sampleRate,
 			pipe.WithName("Mock"),
 			pipe.WithPump(pump),
 			pipe.WithProcessors(processor),

--- a/example/example1.go
+++ b/example/example1.go
@@ -19,6 +19,8 @@ func one() {
 		bufferSize,
 	)
 	check(err)
+	// take wav's sample rate as base
+	sampleRate := wavPump.WavSampleRate()
 
 	// portaudio sink
 	paSink := portaudio.NewSink(
@@ -29,6 +31,7 @@ func one() {
 
 	// build pipe
 	p := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump),
 		pipe.WithSinks(paSink),
 	)

--- a/example/example2.go
+++ b/example/example2.go
@@ -21,6 +21,7 @@ func two() {
 		bufferSize,
 	)
 	check(err)
+	sampleRate := wavPump.WavSampleRate()
 
 	vst2path := "../_testdata/Krush.vst"
 	vst2lib, err := vst2sdk.Open(vst2path)
@@ -45,6 +46,7 @@ func two() {
 	)
 	check(err)
 	p := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump),
 		pipe.WithProcessors(vst2processor),
 		pipe.WithSinks(wavSink),

--- a/example/example3.go
+++ b/example/example3.go
@@ -24,6 +24,7 @@ func three() {
 	check(err)
 	wavPump2, err := wav.NewPump(inPath2, bs)
 	check(err)
+	sampleRate := wavPump1.WavSampleRate()
 
 	wavSink, err := wav.NewSink(
 		outPath,
@@ -36,16 +37,19 @@ func three() {
 	mixer := mixer.New(bs, wavPump1.WavNumChannels())
 
 	track1 := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump1),
 		pipe.WithSinks(mixer),
 	)
 	defer track1.Close()
 	track2 := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump2),
 		pipe.WithSinks(mixer),
 	)
 	defer track2.Close()
 	out := pipe.New(
+		sampleRate,
 		pipe.WithPump(mixer),
 		pipe.WithSinks(wavSink),
 	)

--- a/example/example4.go
+++ b/example/example4.go
@@ -22,6 +22,7 @@ func four() {
 	// wav pump
 	wavPump, err := wav.NewPump(inPath, bufferSize)
 	check(err)
+	sampleRate := wavPump.WavSampleRate()
 
 	// asset sink
 	asset := &asset.Asset{
@@ -30,6 +31,7 @@ func four() {
 
 	// import pipe
 	importAsset := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump),
 		pipe.WithSinks(asset),
 	)
@@ -63,6 +65,7 @@ func four() {
 
 	// final pipe
 	p := pipe.New(
+		sampleRate,
 		pipe.WithPump(track),
 		pipe.WithSinks(wavSink, paSink),
 	)

--- a/example/example5.go
+++ b/example/example5.go
@@ -31,17 +31,20 @@ func five() {
 	wavPump2, err := wav.NewPump(inPath2, bs)
 	check(err)
 
+	sampleRate := wavPump1.WavSampleRate()
 	// mixer
 	mixer := mixer.New(bs, wavPump1.WavNumChannels())
 
 	// track 1
 	track1 := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump1),
 		pipe.WithSinks(mixer),
 	)
 	defer track1.Close()
 	// track 2
 	track2 := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump2),
 		pipe.WithSinks(mixer),
 	)
@@ -76,6 +79,7 @@ func five() {
 
 	// out pipe
 	out := pipe.New(
+		sampleRate,
 		pipe.WithPump(mixer),
 		pipe.WithProcessors(vst2processor),
 		pipe.WithSinks(wavSink),

--- a/mixer/mixer_test.go
+++ b/mixer/mixer_test.go
@@ -59,19 +59,23 @@ func TestMixer(t *testing.T) {
 		BufferSize:  bufferSize,
 		NumChannels: numChannels,
 	}
+	sampleRate := phono.SampleRate(44100)
 	mix := mixer.New(bufferSize, numChannels)
 	sink := &mock.Sink{}
 	playback := pipe.New(
+		sampleRate,
 		pipe.WithName("Playback"),
 		pipe.WithPump(mix),
 		pipe.WithSinks(sink),
 	)
 	track1 := pipe.New(
+		sampleRate,
 		pipe.WithName("Track 1"),
 		pipe.WithPump(pump1),
 		pipe.WithSinks(mix),
 	)
 	track2 := pipe.New(
+		sampleRate,
 		pipe.WithName("Track 2"),
 		pipe.WithPump(pump2),
 		pipe.WithSinks(mix),
@@ -118,21 +122,25 @@ func TestWavMixer(t *testing.T) {
 
 	p1, _ := wav.NewPump(wavPath1, bs)
 	p2, _ := wav.NewPump(wavPath2, bs)
+	sampleRate := p1.WavSampleRate()
 
 	s, _ := wav.NewSink(outPath, p1.WavSampleRate(), p1.WavNumChannels(), p1.WavBitDepth(), p1.WavAudioFormat())
 
 	m := mixer.New(bs, p1.WavNumChannels())
 
 	track1 := pipe.New(
+		sampleRate,
 		pipe.WithPump(p1),
 		pipe.WithSinks(m),
 	)
 	track2 := pipe.New(
+		sampleRate,
 		pipe.WithPump(p2),
 		pipe.WithSinks(m),
 	)
 
 	playback := pipe.New(
+		sampleRate,
 		pipe.WithPump(m),
 		pipe.WithSinks(s),
 	)

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -35,6 +35,7 @@ var (
 		},
 	}
 	bufferSize = phono.BufferSize(10)
+	sampleRate = phono.SampleRate(10)
 )
 
 func TestPipe(t *testing.T) {
@@ -45,6 +46,7 @@ func TestPipe(t *testing.T) {
 	processor := &mock.Processor{}
 	sink := &mock.Sink{}
 	p := pipe.New(
+		sampleRate,
 		pipe.WithName("Mock"),
 		pipe.WithPump(pump),
 		pipe.WithProcessors(processor),

--- a/phono.go
+++ b/phono.go
@@ -2,6 +2,7 @@ package phono
 
 import (
 	"sync"
+	"time"
 )
 
 // Pipe transport types
@@ -54,8 +55,10 @@ type (
 	// Param is a structure for delayed parameters apply
 	// used as return type in functions which enable Params support for different packages
 	Param struct {
-		ID    string
-		Apply ParamFunc
+		ID     string
+		Apply  ParamFunc
+		at     int64
+		atTime time.Duration
 	}
 
 	// Params represent a set of parameters mapped to ID of their receivers
@@ -75,6 +78,22 @@ type (
 	// Tempo represents a tempo value
 	Tempo float32
 )
+
+// At assignes param to sample position
+func (p *Param) At(s int64) *Param {
+	if p != nil {
+		p.at = s
+	}
+	return p
+}
+
+// AtTime assignes param to time position
+func (p *Param) AtTime(d time.Duration) *Param {
+	if p != nil {
+		p.atTime = d
+	}
+	return p
+}
 
 // NewParams returns a new params instance with initialised map inside
 func NewParams(params ...Param) (result *Params) {

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -56,7 +56,8 @@ type SinkRunner interface {
 //	 0..n 	processors
 //	 1..n	sinks
 type Pipe struct {
-	name string
+	name       string
+	sampleRate phono.SampleRate
 	phono.UID
 	cancelFn   context.CancelFunc
 	pump       PumpRunner
@@ -163,8 +164,9 @@ var (
 
 // New creates a new pipe and applies provided params
 // returned pipe is in ready state
-func New(params ...Param) *Pipe {
+func New(sampleRate phono.SampleRate, params ...Param) *Pipe {
 	p := &Pipe{
+		sampleRate:  sampleRate,
 		processors:  make([]ProcessRunner, 0),
 		sinks:       make([]SinkRunner, 0),
 		eventc:      make(chan eventMessage, 100),

--- a/pipe/pipe_test.go
+++ b/pipe/pipe_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/dudk/phono/pipe"
 )
 
-var (
+const (
 	bufferSize = 512
+	sampleRate = 44100
 )
 
 func TestPipeActions(t *testing.T) {
@@ -28,6 +29,7 @@ func TestPipeActions(t *testing.T) {
 
 	// new pipe
 	p := pipe.New(
+		sampleRate,
 		pipe.WithName("Pipe"),
 		pipe.WithPump(pump),
 		pipe.WithProcessors(proc),
@@ -89,6 +91,7 @@ func TestPipe(t *testing.T) {
 	sink2 := &mock.Sink{}
 	// new pipe
 	p := pipe.New(
+		sampleRate,
 		pipe.WithName("Pipe"),
 		pipe.WithPump(pump),
 		pipe.WithProcessors(proc1, proc2),

--- a/portaudio/portaudio_test.go
+++ b/portaudio/portaudio_test.go
@@ -23,10 +23,12 @@ func TestSink(t *testing.T) {
 	}
 	pump, err := wav.NewPump(inFile, bufferSize)
 	assert.Nil(t, err)
+	sampleRate := pump.WavSampleRate()
 	sink := portaudio.NewSink(bufferSize, pump.WavSampleRate(), pump.WavNumChannels())
 	assert.Nil(t, err)
 
 	playback := pipe.New(
+		sampleRate,
 		pipe.WithPump(pump),
 		pipe.WithSinks(sink),
 	)

--- a/track/track_test.go
+++ b/track/track_test.go
@@ -152,6 +152,7 @@ func TestTrackWavSlices(t *testing.T) {
 	}
 
 	p1 := pipe.New(
+		sampleRate,
 		pipe.WithPump(wavPump),
 		pipe.WithSinks(asset),
 	)
@@ -171,6 +172,7 @@ func TestTrackWavSlices(t *testing.T) {
 	track.AddClip(132300, asset.Clip(0, 44100))
 
 	p2 := pipe.New(
+		sampleRate,
 		pipe.WithPump(track),
 		pipe.WithSinks(wavSink),
 	)
@@ -190,6 +192,7 @@ func TestSliceOverlaps(t *testing.T) {
 		}
 
 		p := pipe.New(
+			sampleRate,
 			pipe.WithPump(track),
 			pipe.WithSinks(sink),
 		)

--- a/wav/wav_test.go
+++ b/wav/wav_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	bufferSize = phono.BufferSize(512)
+const (
+	bufferSize = 512
 )
 
 var tests = []struct {
@@ -47,11 +47,13 @@ func TestWavPipe(t *testing.T) {
 	for _, test := range tests {
 		pump, err := wav.NewPump(test.inFile, bufferSize)
 		assert.Nil(t, err)
+		sampleRate := pump.WavSampleRate()
 		sink, err := wav.NewSink(test.outFile, pump.WavSampleRate(), pump.WavNumChannels(), pump.WavBitDepth(), pump.WavAudioFormat())
 		assert.Nil(t, err)
 
 		processor := &mock.Processor{}
 		p := pipe.New(
+			sampleRate,
 			pipe.WithPump(pump),
 			pipe.WithProcessors(processor),
 			pipe.WithSinks(sink),


### PR DESCRIPTION
# Time in phono

Time is required to measure performance and apply parameters at certain moments of time.

# Problem 1. Where to keep SampleRate?

Objectives:
1. Convert time-assigned params to sample-assigned
2. Track if perfromance is not enough for real-time

Option 1: pipe.Pipe

Pros: 
* solves [1]

Cons: 
* not needed here
* doesn't solve [2]

Option 2: Runners

Pros:
* solves [1]
* solves [2]
* exact place where it's needed

Cons:
* How to pass

Option 3: Components (Pump, Processor and Sink)
* doesn't solve [1]
* doesn't solve [2]
* not always needed

Option 2 is preferable

# Problem 2. How to pass SampleRate to Runner?

Objective:
1. Pass SampleRate into runners

Option 1. Use constructor

Pros:
* Small code

Cons:
* Not always mandatory for component
* Not explicit

Option 2. Use Run function to pass SampleRate

Pros:
* Components are not affected
* Explicit

Cons:
* Need to keep value at Pipe

Decision:
* Add SampleRate as param to pipe constructor
* Pass SampleRate into Run functions