### PR TITLE
Fix data race with a feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ os: osx
 install: true
 
 env:
-  - GO111MODULE=on
-  - CODECOV_TOKEN=d9d971f2-368d-46b7-ab06-f605ef2bdb10
+  global:
+    - GO111MODULE=on
+    - CODECOV_TOKEN="d9d971f2-368d-46b7-ab06-f605ef2bdb10"
 
 addons:
   ssh_known_hosts:

--- a/pipe/message.go
+++ b/pipe/message.go
@@ -4,12 +4,10 @@ import "github.com/dudk/phono"
 
 // Message is a main structure for pipe transport
 type message struct {
-	// Buffer of message
-	phono.Buffer
-	// params for pipe
-	*params
-	// ID of original pipe
-	sourceID string
+	phono.Buffer         // Buffer of message
+	*params              // params for pipe
+	sourceID     string  // ID of pipe which spawned this message.
+	feedback     *params //feedback are params applied after processing happened
 }
 
 // NewMessageFunc is a message-producer function


### PR DESCRIPTION
## Feedback

Feedback is needed to retrieve info from pipe after processing occured. This is relevant for ReceivedBy param which we needed to ensure that message was delevered.

## Data race

Data race occured because there was wrong order of message being send and buffer usage. 

## Travis

Also fixed travis environment variables.